### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -17,6 +17,8 @@
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
 name: "Microsoft Defender For Devops"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Hypercaffeinated/NixOSFlakeRepo/security/code-scanning/4](https://github.com/Hypercaffeinated/NixOSFlakeRepo/security/code-scanning/4)

To fix the issue, a `permissions` block should be added to the workflow to explicitly define the minimal permissions required. Based on the actions used in this workflow (`actions/checkout`, `actions/setup-dotnet`, `microsoft/security-devops-action`, and `github/codeql-action/upload-sarif`), the `contents: read` permission is the minimum required to read repository content. If no write permissions are explicitly required by the steps, they should be omitted.

The `permissions` block will be added at the workflow level to ensure all jobs in the workflow inherit the same minimal permissions unless explicitly overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
