### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -21,6 +21,9 @@
 
 name: Appknox
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Hypercaffeinated/NixOSFlakeRepo/security/code-scanning/1](https://github.com/Hypercaffeinated/NixOSFlakeRepo/security/code-scanning/1)

To address the detected issue, we need to explicitly set permissions for the workflow to minimize the access granted to the `GITHUB_TOKEN`. The recommended permissions should include:
- `contents: read` to allow read access to repository contents, which is typically sufficient for workflows like this.
- Any additional permissions required for specific steps, such as uploading SARIF files to GitHub Advanced Security.

The `permissions` block should be added at the root of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
